### PR TITLE
Update SymfonyCookieReader.php

### DIFF
--- a/src/Cookie/Adapter/SymfonyCookieReader.php
+++ b/src/Cookie/Adapter/SymfonyCookieReader.php
@@ -18,7 +18,7 @@ final class SymfonyCookieReader implements CookieReaderInterface
 
     public function getValue(string $name): ?string
     {
-        $request = $this->requestStack->getMasterRequest();
+        $request = $this->requestStack->getMainRequest();
         if (null === $request) {
             return null;
         }


### PR DESCRIPTION
getMasterRequest() was deprecated since 5.3 and it was renamed in Symfony 6.0